### PR TITLE
Bug #4 - Search Providers Reset Button

### DIFF
--- a/src/app/app-filters.js
+++ b/src/app/app-filters.js
@@ -180,10 +180,6 @@ angular.module('appFilters', [
 			return providers;
 		}
 
-		if (action === 'update') {
-			$scope.data.filtered.search = null;
-		}
-
 		$q.when().then(function() {
 			_(providers).forEach(function(provider) {
 				if (action === 'reset') {


### PR DESCRIPTION
Al setear el filtro a $scope.data.filtered.search = null; la logica del boton reset estaba detectado que no había ningún filtro aplicado